### PR TITLE
readme: Fix typo in defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ configure them as something other than the defaults.
 | `ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION` | 10m | Time to wait to delete containers for a stopped task. If set to less than 1 minute, the value is ignored.  | 3h | 3h |
 | `ECS_CONTAINER_STOP_TIMEOUT` | 10m | Time to wait for the container to exit normally before being forcibly killed. | 30s | 30s |
 | `ECS_ENABLE_TASK_IAM_ROLE` | `true` | Whether to enable IAM Roles for Tasks on the Container Instance | `false` | `false` |
-| `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST` | `true` | Whether to enable IAM Roles for Tasks when launched with `host` network mode on the Container Instance | `false` | `fasle` |
+| `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST` | `true` | Whether to enable IAM Roles for Tasks when launched with `host` network mode on the Container Instance | `false` | `false` |
 | `ECS_DISABLE_IMAGE_CLEANUP` | `true` | Whether to disable automated image cleanup for the ECS Agent. | `false` | `false` |
 | `ECS_IMAGE_CLEANUP_INTERVAL` | 30m | The time interval between automated image cleanup cycles. If set to less than 10 minutes, the value is ignored. | 30m | 30m |
 | `ECS_IMAGE_MINIMUM_CLEANUP_AGE` | 30m | The minimum time interval between when an image is pulled and when it can be considered for automated image cleanup. | 1h | 1h |


### PR DESCRIPTION
This commit fixes a typo in ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST from `fasle` to `false`.

### Summary

Randomly noticed this typo while adjusting some flags as part of our ECS setup. 

### Implementation details

None

### Testing

N/A

### Description for the changelog

I think this is minor enough to be outside the changelog.

### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes
